### PR TITLE
Fix building with node > 6

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -6,7 +6,7 @@ WORKDIR /usr/src/app
 
 COPY package.json .
 
-RUN JOBS=MAX npm install --unsafe-perm --production && npm cache clean
+RUN JOBS=MAX npm install --unsafe-perm --production
 
 COPY . ./
 


### PR DESCRIPTION
Temporarily remove the cache cleaning code which breaks in later versions of node.

Change-type: patch
Signed-off-by: Cameron Diver <cameron@resin.io>