### PR TITLE
pin nodejs v6

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM resin/%%RESIN_MACHINE_NAME%%-node
+FROM resin/%%RESIN_MACHINE_NAME%%-node:6
 
 ENV INITSYSTEM on
 


### PR DESCRIPTION
with nodeJS versions > 6 the application does not work (getting unhandled error event listeners from core ) so it might be a good idea to pin v6 base image while we figure it out 