### PR TITLE
Lock node to 8.5.0

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM resin/%%RESIN_MACHINE_NAME%%-node
+FROM resin/%%RESIN_MACHINE_NAME%%-node:8.5.0
 
 ENV INITSYSTEM on
 


### PR DESCRIPTION
This lets us avoid `ESPIPE: invalid seek, read` errors, seemingly caused by https://github.com/nodejs/node/issues/19240