### PR TITLE
Leverage Docker's multi stage build

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,13 +1,17 @@
-FROM resin/%%RESIN_MACHINE_NAME%%-node:8.5.0
-
-ENV INITSYSTEM on
+FROM resin/%%RESIN_MACHINE_NAME%%-node:8.5.0 AS base
 
 WORKDIR /usr/src/app
 
 COPY package.json .
-
 RUN JOBS=MAX npm install --unsafe-perm --production
 
+
+FROM resin/%%RESIN_MACHINE_NAME%%-node:8.5.0-slim
+
+ENV INITSYSTEM on
+
+WORKDIR /usr/src/app
+COPY --from=base /usr/src/app/node_modules ./node_modules
 COPY . ./
 
 RUN node --check src/app.js


### PR DESCRIPTION
Using Docker's multi stage build to build node_modules with the :node image, and then switching to the node-slim base image reduces the final image size from 450mb to 185mb

This should help to reduce wait times and wifi usage a fair bit when we use this example in our workshops.

Change-type: patch