### PR TITLE
Make the 64 bits OSes use 32 bits base images.

### DIFF
--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,0 +1,19 @@
+FROM balenalib/raspberrypi3-node:8-build AS base
+
+WORKDIR /usr/src/app
+
+COPY package.json .
+RUN JOBS=MAX npm install --unsafe-perm --production
+
+
+FROM balenalib/raspberrypi3-node:8
+
+ENV INITSYSTEM on
+
+WORKDIR /usr/src/app
+COPY --from=base /usr/src/app/node_modules ./node_modules
+COPY . ./
+
+RUN node --check src/app.js
+
+CMD node src/app.js


### PR DESCRIPTION
Currently if we use the 64 bits base images then sense-joystick
won't detect any joystick events.

Signed-off-by: Florin Sarbu <florin@balena.io>